### PR TITLE
Implement CSV Import Functionality for Box Brands

### DIFF
--- a/src/components/box-brands/AddBoxBrandsForm.tsx
+++ b/src/components/box-brands/AddBoxBrandsForm.tsx
@@ -30,6 +30,7 @@ import InputFieldStrippingSelect from './container/stripping/InputFieldStripping
 import StrippingSelectBanContainer from './container/stripping/StrippingSelectBanContainer';
 import InputFieldThermographSelect from './container/thermograph/InputFieldThermographSelect';
 import ThermographSelectBanContainer from './container/thermograph/ThermographSelectBanContainer';
+import ImportBoxBrandDrawer from './ImportBoxBrandDrawer';
 import InputFieldsBanContainer from './InputFieldsBanContainer';
 import BandSelectBanContanier from './materials/band/BandSelectBanContanier';
 import InputFieldBandSelect from './materials/band/InputFieldBandSelect';
@@ -46,6 +47,7 @@ import SelectPesticide from './post-harvest/pesticide/SelectPesticide';
 import InputFieldBrandSelect from './specifications/brand/InputFieldBrandSelect';
 import InputFieldRequiredCertificateMultiSelect from './specifications/requiredCertificate/InputFieldRequiredCertificateMultiSelect';
 import { PesticideType } from '../../types/box-brand/post-harvest/pesticide';
+import ImportProducerDrawer from '../producer/ImportProducerDrawer';
 import CheckboxForm from '../ui/form/CheckboxForm';
 import InputFieldNumber from '../ui/form/InputFieldNumber';
 import InputFieldQuantity from '../ui/form/InputFieldQuantity';
@@ -966,9 +968,12 @@ export default function AddBoxBrandsForm() {
         {({ isSubmitting, values }) => (
           <Form>
             <Flex flexDirection='column' gap={3}>
-              <Heading fontSize={'2xl'} p={'12px'}>
-                Especificaciones
-              </Heading>
+              <Flex justify='space-between'>
+                <Heading fontSize={'2xl'} p={'12px'}>
+                  Especificaciones
+                </Heading>
+                <ImportBoxBrandDrawer />
+              </Flex>
               <Divider mb={'16px'} />
 
               <SimpleGrid columns={{ base: 1, sm: 2 }} spacing={5}>

--- a/src/components/box-brands/ImportBoxBrandDrawer.tsx
+++ b/src/components/box-brands/ImportBoxBrandDrawer.tsx
@@ -1,0 +1,225 @@
+import {
+  Box,
+  Button,
+  Drawer,
+  DrawerBody,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerOverlay,
+  DrawerContent,
+  DrawerCloseButton,
+  Input,
+  useDisclosure,
+  Text,
+  FormControl,
+  FormLabel,
+  Spinner,
+  Image,
+  VStack,
+  HStack,
+  useToast,
+} from '@chakra-ui/react';
+import { useField } from 'formik';
+import React, { useEffect, useRef, useState } from 'react';
+import { useImportBoxBrands } from '../../hooks/box-brand/uploadBoxBrands';
+
+const ImportBoxBrandDrawer: React.FC = () => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [fileName, setFileName] = useState<string>('');
+  const [fileSize, setFileSize] = useState<number>(0);
+  const [dragging, setDragging] = useState(false);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [field, meta, helpers] = useField('import-boxBrand');
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const toast = useToast();
+
+  const { importBoxBrands, isLoading } = useImportBoxBrands({
+    config: {
+      onSuccess: (data) => {
+        toast({
+          title: 'Importación exitosa',
+          description: `Se importaron productores correctamente.`,
+          status: 'success',
+          duration: 5000,
+          isClosable: true,
+        });
+        resetFile();
+        onClose();
+      },
+      onError: (error: any) => {
+        toast({
+          title: 'Error al importar',
+          description: error.response?.data?.message || 'Error desconocido.',
+          status: 'error',
+          duration: 5000,
+          isClosable: true,
+        });
+      },
+    },
+  });
+
+  const handleFileChange = (file: File) => {
+    if (file) {
+      setSelectedFile(file);
+      setFileName(file.name);
+      setFileSize(file.size);
+      helpers.setValue(file);
+
+      if (fileInputRef.current) {
+        fileInputRef.current.value = '';
+      }
+    }
+  };
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (event.target.files && event.target.files.length > 0) {
+      const file = event.target.files[0];
+      handleFileChange(file);
+    }
+  };
+
+  const handleDragEnter = (e: React.DragEvent) => {
+    e.preventDefault();
+    setDragging(true);
+  };
+
+  const handleDragLeave = (e: React.DragEvent) => {
+    e.preventDefault();
+    setDragging(false);
+  };
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+    setDragging(true);
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    setDragging(false);
+
+    const file = e.dataTransfer.files?.[0];
+    if (file) handleFileChange(file);
+  };
+
+  const resetFile = () => {
+    setFileName('');
+    setFileSize(0);
+    setSelectedFile(null);
+    helpers.setValue(null);
+  };
+
+  const handleUpload = () => {
+    if (selectedFile) importBoxBrands(selectedFile);
+  };
+
+  return (
+    <Box>
+      <Button py='8px' px='16px' colorScheme='teal' onClick={onOpen}>
+        Importar Marcas
+      </Button>
+
+      <Drawer isOpen={isOpen} placement='right' onClose={onClose}>
+        <DrawerOverlay />
+        <DrawerContent>
+          <DrawerCloseButton />
+          <DrawerHeader>Importar Marca de Caja</DrawerHeader>
+
+          <DrawerBody>
+            {fileName ? (
+              <Box
+                border='1px solid'
+                borderColor='gray.200'
+                borderRadius='md'
+                p={4}
+                bg='teal.50'
+                shadow='md'
+              >
+                <HStack justify='space-between'>
+                  <VStack align='start' spacing={1}>
+                    <Text fontWeight='bold' fontSize='lg'>
+                      Archivo seleccionado
+                    </Text>
+                    <Text fontSize='sm' color='gray.600'>
+                      Nombre: <b>{fileName}</b>
+                    </Text>
+                    <Text fontSize='sm' color='gray.600'>
+                      Tamaño: <b>{(fileSize / 1024).toFixed(2)} KB</b>
+                    </Text>
+                  </VStack>
+                  <Button
+                    size='sm'
+                    colorScheme='red'
+                    variant='outline'
+                    onClick={resetFile}
+                  >
+                    Quitar
+                  </Button>
+                </HStack>
+              </Box>
+            ) : (
+              <FormControl id='import-boxBrand' width='100%'>
+                <Box
+                  onDragEnter={handleDragEnter}
+                  onDragLeave={handleDragLeave}
+                  onDragOver={handleDragOver}
+                  onDrop={handleDrop}
+                  border='2px dashed'
+                  borderColor={dragging ? 'teal.500' : 'gray.300'}
+                  borderRadius='md'
+                  textAlign='center'
+                  bg={dragging ? 'teal.50' : 'white'}
+                  cursor='pointer'
+                >
+                  <Input
+                    ref={fileInputRef}
+                    id={field.name}
+                    type='file'
+                    accept='.csv'
+                    display='none'
+                    onChange={handleChange}
+                  />
+                  <FormLabel>
+                    {isLoading ? (
+                      <Spinner />
+                    ) : (
+                      <Image
+                        src={'/uploaded.png'}
+                        alt='Subida de archivo'
+                        maxH='200px'
+                        my={2}
+                        mx='auto'
+                      />
+                    )}
+                    <Text p={4} color={dragging ? 'teal.500' : 'gray.300'}>
+                      {dragging
+                        ? 'Suelta aquí...'
+                        : 'Arrastra y suelta un archivo aquí, o haz clic para seleccionar uno'}
+                    </Text>
+                  </FormLabel>
+                </Box>
+              </FormControl>
+            )}
+          </DrawerBody>
+
+          <DrawerFooter>
+            <Button variant='outline' mr={3} onClick={onClose}>
+              Cancelar
+            </Button>
+            <Button
+              py='8px'
+              px='16px'
+              colorScheme='teal'
+              isDisabled={!selectedFile}
+              onClick={handleUpload}
+              isLoading={isLoading}
+            >
+              Subir
+            </Button>
+          </DrawerFooter>
+        </DrawerContent>
+      </Drawer>
+    </Box>
+  );
+};
+
+export default ImportBoxBrandDrawer;

--- a/src/hooks/box-brand/uploadBoxBrands.ts
+++ b/src/hooks/box-brand/uploadBoxBrands.ts
@@ -1,0 +1,35 @@
+import { useMutation } from 'react-query';
+import axios from '@/lib/axios';
+import { MutationConfig } from '@/lib/react-query';
+
+interface ImportBoxBrandsResponse {
+  message: string;
+}
+
+export const importBoxBrands = (
+  file: File
+): Promise<ImportBoxBrandsResponse> => {
+  const formData = new FormData();
+  formData.append('file', file);
+
+  return axios.post('/box-brand/upload-csv', formData, {
+    headers: {
+      'Content-Type': 'multipart/form-data',
+    },
+  });
+};
+
+type UseImportBoxBrandsOptions = {
+  config?: MutationConfig<typeof importBoxBrands>;
+};
+
+export const useImportBoxBrands = ({
+  config,
+}: UseImportBoxBrandsOptions = {}) => {
+  const mutation = useMutation({
+    mutationFn: importBoxBrands,
+    ...config,
+  });
+
+  return { ...mutation, importBoxBrands: mutation.mutate };
+};

--- a/src/hooks/merchants/uploadMerchants.ts
+++ b/src/hooks/merchants/uploadMerchants.ts
@@ -12,7 +12,7 @@ export const importMerchants = (
   const formData = new FormData();
   formData.append('file', file);
 
-  return axios.post('/merchant/upload', formData, {
+  return axios.post('/merchant/business/import', formData, {
     headers: {
       'Content-Type': 'multipart/form-data',
     },


### PR DESCRIPTION
This pull request introduces a dedicated CSV import functionality for box brands, streamlining the bulk addition process:
- Developed `ImportBoxBrandDrawer` for user-friendly CSV file uploads.
- Enhanced `uploadBoxBrands` hook to support efficient parsing and data handling of CSV imports.
These improvements are crucial for optimizing the management of box brands, allowing for faster and more efficient data entry and integration.